### PR TITLE
Bumping minimum redis client version to 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,29 @@
 # Change Log
+
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.3.0] - 2021-09-09
+## [0.4.0] - 2023-11-10
+
 ### Changed
+
+- Minimum required Redis client version bumped to 5.0+
+- Updated the code to support the current Redis API
+
+## [0.3.0] - 2021-09-09
+
+### Changed
+
 - Upgrade redis
 
 ## [0.2.0] - 2020-12-16
+
 ### Changed
+
 - A single require for both classes
 
 ## [0.1.0] - 2020-12-14
+
 ### Added
+
 - Initial release

--- a/README.md
+++ b/README.md
@@ -12,14 +12,20 @@ gem 'reliable-queue-rb', '~> 0.3.0'
 
 And then execute:
 
-    $ bundle
+```sh
+bundle
+```
 
 Or install it yourself as:
 
-    $ gem install reliable-queue-rb
+```sh
+gem install reliable-queue-rb
+```
 
 ## Usage
+
 Reliable Queue
+
 ```ruby
 queue = ReliableQueue.new(redis_queue, redis_client)
 
@@ -29,6 +35,7 @@ end
 ```
 
 ChunkedReliableQueue
+
 ```ruby
 queue = ChunkedReliableQueue.new(working_on_queue_suffix, redis_queue, redis_client)
 
@@ -39,7 +46,7 @@ end
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/altmetric/reliable-queue-rb.
+Bug reports and pull requests are welcome on GitHub at <https://github.com/altmetric/reliable-queue-rb>.
 
 ## License
 

--- a/lib/reliable_queue_rb/chunked_reliable_queue.rb
+++ b/lib/reliable_queue_rb/chunked_reliable_queue.rb
@@ -16,7 +16,7 @@ class ChunkedReliableQueue
     return enum_for(:each_slice, size) unless block_given?
 
     loop do
-      blocking_reply = redis.brpoplpush(queue, working_queue, 30)
+      blocking_reply = redis.brpoplpush(queue, working_queue, timeout: 30)
       next unless blocking_reply
 
       replies = [blocking_reply]

--- a/lib/reliable_queue_rb/reliable_queue.rb
+++ b/lib/reliable_queue_rb/reliable_queue.rb
@@ -15,7 +15,7 @@ class ReliableQueue
     return enum_for(:each) unless block_given?
 
     loop do
-      reply = redis.brpoplpush(queue, working_queue, 30)
+      reply = redis.brpoplpush(queue, working_queue, timeout: 30)
       next unless reply
 
       yield reply

--- a/reliable_queue.gemspec
+++ b/reliable_queue.gemspec
@@ -1,17 +1,18 @@
 Gem::Specification.new do |s|
+  s.required_ruby_version = '>= 2.7.0'
   s.name        = 'reliable-queue-rb'
-  s.version     = '0.3.0'
-  s.authors     = ['Anna Klimas','Jonathan Hernandez']
+  s.version     = '0.4.0'
+  s.authors     = ['Anna Klimas', 'Jonathan Hernandez']
   s.email       = ['support@altmetric.com']
 
-  s.summary     = "Ruby library for reliable queue processing."
+  s.summary     = 'Ruby library for reliable queue processing.'
   s.homepage    = 'https://github.com/altmetric/reliable-queue-rb'
-  s.license     = "MIT"
+  s.license     = 'MIT'
 
   s.files = Dir['*.{md,txt}', 'lib/**/*.rb']
   s.test_files = Dir['spec/**/*.rb']
 
-  s.add_dependency 'redis', '>= 3.0.0', '< 5.0.0'
+  s.add_dependency 'redis', '>= 5.0.0'
   s.add_development_dependency('rake', '~> 10.0')
   s.add_development_dependency('rspec', '~> 3.10')
 end


### PR DESCRIPTION
In order to support redis client versions 5.0+ few minor changes were needed in the code. This release `0.4.0` will now require `'redis', '>= 5.0.0'`.