### PR TITLE
Replace deprecated Redis commands, bump to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## UNRELEASED - 2024-10-18
+## [1.0.0] - 2026-03-27
 
 ### Changed
 
+- Replace deprecated `rpoplpush`/`brpoplpush` with `lmove`/`blmove` (requires Redis 6.2+)
 - Modernise dev dependencies
 - Replace Travis CI with GitHub Actions
 - Add house_style and apply the corrections

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Ruby reliable queue implementation on top of Redis. It makes sure that message is not lost between popping it from Redis queue and compeleting the task.
 
+## Requirements
+
+- Redis 6.2 or later
+
 ## Installation
 
 Add this line to your application's `Gemfile`:

--- a/lib/reliable_queue_rb/chunked_reliable_queue.rb
+++ b/lib/reliable_queue_rb/chunked_reliable_queue.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class ChunkedReliableQueue
   DEFAULT_SIZE = 100
 
-  attr_reader :name, :queue, :size, :working_queue, :redis
+  attr_reader :name, :queue, :working_queue, :redis
 
   def initialize(name, queue, redis)
     @name = name
@@ -16,20 +18,20 @@ class ChunkedReliableQueue
     return enum_for(:each_slice, size) unless block_given?
 
     loop do
-      blocking_reply = redis.brpoplpush(queue, working_queue, timeout: 30)
+      blocking_reply = redis.blmove(queue, working_queue, 'RIGHT', 'LEFT', timeout: 30)
       next unless blocking_reply
 
       replies = [blocking_reply]
       replies += redis.multi { |multi|
         (size - 1).times do
-          multi.rpoplpush(queue, working_queue)
+          multi.lmove(queue, working_queue, 'RIGHT', 'LEFT')
         end
       }.compact
 
       yield replies
       redis.multi do |multi|
         replies.each do |reply|
-          multi.lrem(working_queue, 0, reply)
+          multi.lrem(working_queue, 1, reply)
         end
       end
     end
@@ -38,6 +40,6 @@ class ChunkedReliableQueue
   private
 
   def requeue_unfinished_work
-    loop while redis.rpoplpush(working_queue, queue)
+    loop while redis.lmove(working_queue, queue, 'RIGHT', 'LEFT')
   end
 end

--- a/lib/reliable_queue_rb/reliable_queue.rb
+++ b/lib/reliable_queue_rb/reliable_queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReliableQueue
   include Enumerable
 
@@ -15,17 +17,17 @@ class ReliableQueue
     return enum_for(:each) unless block_given?
 
     loop do
-      reply = redis.brpoplpush(queue, working_queue, timeout: 30)
+      reply = redis.blmove(queue, working_queue, 'RIGHT', 'LEFT', timeout: 30)
       next unless reply
 
       yield reply
-      redis.lrem(working_queue, 0, reply)
+      redis.lrem(working_queue, 1, reply)
     end
   end
 
   private
 
   def requeue_unfinished_work
-    loop while redis.rpoplpush(working_queue, queue)
+    loop while redis.lmove(working_queue, queue, 'RIGHT', 'LEFT')
   end
 end

--- a/reliable_queue.gemspec
+++ b/reliable_queue.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
   s.name        = 'reliable-queue-rb'
-  s.version     = '0.4.0'
+  s.version     = '1.0.0'
   s.authors     = ['Anna Klimas', 'Jonathan Hernandez']
   s.email       = ['support@altmetric.com']
 


### PR DESCRIPTION
Replace deprecated rpoplpush/brpoplpush with lmove/blmove, which were introduced in Redis 6.2. This is a breaking change for users on Redis < 6.2, hence the major version bump to 1.0.0.

Additional improvements:
- Add frozen_string_literal pragma to source files
- Remove unused `size` attr_reader from ChunkedReliableQueue
- Use lrem count 1 instead of 0 since each item appears exactly once in the working queue, avoiding unnecessary list scans